### PR TITLE
Fix falling offset to remove blank squares

### DIFF
--- a/main.c
+++ b/main.c
@@ -242,7 +242,7 @@ static void startFall(void) {
             if (board[y][x] != -1) {
                 board[write][x] = board[y][x];
                 if (write != y)
-                    fallOffset[write][x] = (float)(y - write) * TILE_SIZE;
+                    fallOffset[write][x] = (float)(write - y) * TILE_SIZE;
                 else
                     fallOffset[write][x] = 0.f;
                 write--;


### PR DESCRIPTION
## Summary
- ensure candies drop from the correct height by using a positive fall offset

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68aa1a56d7288326bba47365b96da0ba