### PR TITLE
Fix new candy spawn offset

### DIFF
--- a/main.c
+++ b/main.c
@@ -248,9 +248,10 @@ static void startFall(void) {
                 write--;
             }
         }
+        int newCount = write + 1;
         while (write >= 0) {
             board[write][x] = rand() % CANDY_TYPES;
-            fallOffset[write][x] = (float)(write + 1) * TILE_SIZE;
+            fallOffset[write][x] = (float)newCount * TILE_SIZE;
             write--;
         }
     }


### PR DESCRIPTION
## Summary
- stack newly spawned candies above the board so they fall in sequence instead of overlapping

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68aa1dc2ddf4832687a55c687251f8aa