### PR TITLE
Add simple sound effects and background loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 CFLAGS=`sdl2-config --cflags` -Wall -Wextra -std=c11
-LDFLAGS=`sdl2-config --libs` -lSDL2_image -lSDL2_mixer -lSDL2_ttf
+LDFLAGS=`sdl2-config --libs` -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lm
 TARGET=candycrush
 
 all: $(TARGET)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # candyCrush
 
 Simple match-3 puzzle game built with SDL2.
+Now includes procedurally generated sound effects for swapping, invalid moves, landing candies, and a looping background tone.
 
 ## Controls
 


### PR DESCRIPTION
## Summary
- Generate swap, invalid, land, and music tones at runtime
- Link against libm for sine wave generation
- Note procedural audio in README

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68aa32d614a083268e5072bc20282f7f