### PR TITLE
Add grid lines and selection highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Simple match-3 puzzle game built with SDL2.
 Now includes procedurally generated sound effects for swapping, invalid moves, landing candies, and a looping background tone.
+The board renders grid lines for clarity and the currently selected candy is outlined to make swaps easier.
 
 ## Controls
 

--- a/main.c
+++ b/main.c
@@ -92,6 +92,7 @@ static Mix_Chunk* sndSwap = NULL;
 static Mix_Chunk* sndInvalid = NULL;
 static Mix_Chunk* sndLand = NULL;
 static Mix_Chunk* sndMusic = NULL;
+static int selectedX = -1, selectedY = -1;
 
 static Mix_Chunk* generateTone(int freq, int ms) {
     int sampleRate = 44100;
@@ -315,6 +316,19 @@ static void renderBoard(SDL_Renderer* renderer) {
             SDL_RenderCopy(renderer, candyTexture, NULL, &dst);
         }
     }
+
+    SDL_SetRenderDrawColor(renderer, 40, 40, 40, 255);
+    for (int i = 0; i <= GRID_SIZE; ++i) {
+        SDL_RenderDrawLine(renderer, i * TILE_SIZE, 0, i * TILE_SIZE, GRID_SIZE * TILE_SIZE);
+        SDL_RenderDrawLine(renderer, 0, i * TILE_SIZE, GRID_SIZE * TILE_SIZE, i * TILE_SIZE);
+    }
+
+    if (selectedX >= 0 && selectedY >= 0 && gameState == STATE_IDLE) {
+        SDL_Rect sel = {selectedX * TILE_SIZE, selectedY * TILE_SIZE, TILE_SIZE, TILE_SIZE};
+        SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+        SDL_RenderDrawRect(renderer, &sel);
+    }
+
     renderScore(renderer);
     if (gameState == STATE_GAMEOVER) {
         const char* msg = "No moves! Press R to restart";
@@ -334,8 +348,6 @@ static void renderBoard(SDL_Renderer* renderer) {
     }
     SDL_RenderPresent(renderer);
 }
-
-static int selectedX = -1, selectedY = -1;
 
 static void handleInput(SDL_Event* e) {
     if (gameState == STATE_GAMEOVER && e->type == SDL_KEYDOWN && e->key.keysym.sym == SDLK_r) {


### PR DESCRIPTION
## Summary
- Draw grid lines to better delineate the game board
- Outline the currently selected candy for clearer swaps
- Document grid lines and selection outline in README

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68aa36155c488326baf2e42633b97546