### PR TITLE
Use fruit icons for candies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # candyCrush
 
 Simple match-3 puzzle game built with SDL2.
+Now uses fruit icons for candies instead of colored balls.
 Now includes procedurally generated sound effects for swapping, invalid moves, landing candies, and a looping background tone.
 The board renders grid lines for clarity and the currently selected candy is outlined to make swaps easier.
 


### PR DESCRIPTION
## Summary
- replace procedural ball texture with fruit icon textures for all candies and expand to ten types
- initialize SDL_image with JPEG support for loading the new assets
- document the use of fruit icons in the README

## Testing
- `/usr/bin/make` *(fails: sdl2-config and gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4381a87c8326a488ed4a3be64106